### PR TITLE
Draft: in 句バインドの複数指定対応

### DIFF
--- a/eval.go
+++ b/eval.go
@@ -51,16 +51,23 @@ func build(tokens []token, inputParams map[string]interface{}) (string, []interf
 	for _, token := range tokens {
 		if token.kind == tkBind {
 			if elem, ok := inputParams[token.value]; ok {
-				switch slice := elem.(type) {
+				switch elemTyp := elem.(type) {
 				case []string:
-					token.str = bindLiterals(token.str, len(slice))
-					for _, value := range slice {
+					token.str = bindLiterals(token.str, len(elemTyp))
+					for _, value := range elemTyp {
 						params = append(params, value)
 					}
 				case []int:
-					token.str = bindLiterals(token.str, len(slice))
-					for _, value := range slice {
+					token.str = bindLiterals(token.str, len(elemTyp))
+					for _, value := range elemTyp {
 						params = append(params, value)
+					}
+				case [][]interface{}:
+					token.str = bindTable(token.str, len(elemTyp), len(elemTyp[0]))
+					for _, rows := range elemTyp {
+						for _, columns := range rows {
+							params = append(params, columns)
+						}
 					}
 				default:
 					params = append(params, elem)
@@ -90,6 +97,34 @@ func bindLiterals(str string, number int) string {
 	b.WriteRune(')')
 
 	return fmt.Sprint(b.String(), str)
+}
+
+func bindTable(str string, rowNumber, columnNumber int) string {
+	str = strings.TrimLeftFunc(str, func(r rune) bool {
+		return r != unicode.SimpleFold('/')
+	})
+
+	var column strings.Builder
+	column.WriteRune('(')
+	for i := 0; i < columnNumber; i++ {
+		column.WriteRune('?')
+		if i != columnNumber-1 {
+			column.WriteString(", ")
+		}
+	}
+	column.WriteRune(')')
+
+	var row strings.Builder
+	row.WriteRune('(')
+	for i := 0; i < rowNumber; i++ {
+		row.WriteString(column.String())
+		if i != rowNumber-1 {
+			row.WriteString(", ")
+		}
+	}
+	row.WriteRune(')')
+
+	return fmt.Sprint(row.String(), str)
 }
 
 func formatQuery(query string) string {

--- a/tokenizer.go
+++ b/tokenizer.go
@@ -76,9 +76,23 @@ func tokenize(str string) ([]token, error) {
 			if tok.kind == 0 {
 				tok.kind = tkBind
 				if quote := str[index]; quote == '(' {
-					// /* ... */( ... )
+					// /* ... */( ... ) or /* ... */( (...), (...) )
+					var quoteStack []interface{}
 					index++
-					for index < length && str[index] != ')' {
+					for index < length {
+						if str[index] == '(' {
+							quoteStack = append(quoteStack, struct{}{})
+							index++
+							continue
+						}
+						if str[index] == ')' {
+							if len(quoteStack) == 0 {
+								break
+							}
+							quoteStack = quoteStack[0 : len(quoteStack)-1]
+							index++
+							continue
+						}
 						index++
 					}
 					if str[index] != ')' {

--- a/tokenizer_test.go
+++ b/tokenizer_test.go
@@ -328,6 +328,41 @@ func TestTokenize(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "multiple in bind",
+			input: `SELECT * FROM person /* IF gender_list !== null */ WHERE (person.gender, person.firstName) in /*table*/('M', 'Jeff') /* END */`,
+			want: []token{
+				{
+					kind: tkSQLStmt,
+					str:  "SELECT * FROM person ",
+				},
+				{
+					kind:      tkIf,
+					str:       "/* IF gender_list !== null */",
+					condition: "gender_list !== null",
+				},
+				{
+					kind: tkSQLStmt,
+					str:  " WHERE (person.gender, person.firstName) in ",
+				},
+				{
+					kind:  tkBind,
+					str:   "?/*table*/",
+					value: "table",
+				},
+				{
+					kind: tkSQLStmt,
+					str:  " ",
+				},
+				{
+					kind: tkEnd,
+					str:  "/* END */",
+				},
+				{
+					kind: tkEndOfProgram,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
https://github.com/future-architect/go-twowaysql/pull/13 マージ後に マージ先を master へ変更して オープン予定

## 概要

IN 句に複数のカラム指定を可能とする対応を実施しました。

## 実行 SQL

```sql
SELECT
*
FROM person 
WHERE 
  name = /*name*/'name'
  AND 
  (a, b) IN /*table*/(('x', 10), ('y', 11))
```