### PR TITLE
Add sql comment support

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -45,7 +45,20 @@ func TestSelect(t *testing.T) {
 		},
 	}
 
-	err := tw.Select(ctx, &people, `SELECT first_name, last_name, email FROM persons WHERE employee_no < /*maxEmpNo*/1000 /* IF deptNo */ AND dept_no < /*deptNo*/1 /* END */`, &params)
+	sql := `-- comment
+		SELECT
+			first_name
+		,	last_name
+		,	email
+		FROM
+			persons
+		WHERE
+			employee_no	<	/*maxEmpNo*/1000 -- comment
+			/* IF deptNo */
+			AND	dept_no		<	/*deptNo*/1
+			/* END */
+		-- comment`
+	err := tw.Select(ctx, &people, sql, &params)
 	if err != nil {
 		t.Errorf("select: failed: %v", err)
 	}

--- a/eval.go
+++ b/eval.go
@@ -16,8 +16,6 @@ import (
 func Eval(inputQuery string, inputParams interface{}) (string, []interface{}, error) {
 	mapParams := map[string]interface{}{}
 
-	query := formatQuery(inputQuery)
-
 	if inputParams != nil {
 		if err := encode(mapParams, inputParams); err != nil {
 			return "", nil, err
@@ -26,7 +24,7 @@ func Eval(inputQuery string, inputParams interface{}) (string, []interface{}, er
 		mapParams = nil
 	}
 
-	tokens, err := tokenize(query)
+	tokens, err := tokenize(inputQuery)
 	if err != nil {
 		return "", nil, err
 	}
@@ -125,13 +123,6 @@ func bindTable(str string, rowNumber, columnNumber int) string {
 	row.WriteRune(')')
 
 	return fmt.Sprint(row.String(), str)
-}
-
-func formatQuery(query string) string {
-	query = strings.ReplaceAll(query, "\n", " ")
-	query = strings.ReplaceAll(query, "\t", " ")
-	query = strings.TrimSpace(query)
-	return query
 }
 
 // 空白が二つ以上続いていたら一つにする。=1 -> = 1のような変換はできない

--- a/eval_test.go
+++ b/eval_test.go
@@ -334,7 +334,6 @@ func TestEval(t *testing.T) {
 				GenderList: []string{"M", "F"},
 				IntList:    []int{1, 2, 3},
 			},
-			// wantQuery:  `SELECT * FROM person WHERE employee_no < 1000 AND id = 3`,
 			wantQuery: `
 			SELECT
 				*
@@ -480,7 +479,6 @@ func TestEval(t *testing.T) {
 				EmpNo:    1000,
 				MaxEmpNo: 10,
 			},
-			// wantQuery:  `SELECT * FROM person WHERE 1=1 AND id = ?/*maxEmpNo*/`,
 			wantQuery: `
 			SELECT
 				*
@@ -524,7 +522,6 @@ func TestEval(t *testing.T) {
 				EmpNo:    1000,
 				MaxEmpNo: 10,
 			},
-			// wantQuery:  `SELECT * FROM person WHERE 1=1 AND employee_no < ?/*EmpNo*/ AND id = ?/*maxEmpNo*/`,
 			wantQuery: `
 			SELECT
 				*
@@ -572,7 +569,6 @@ func TestEval(t *testing.T) {
 				EmpNo:    1000,
 				MaxEmpNo: 10,
 			},
-			// wantQuery:  `SELECT * FROM person WHERE 1=1 AND employee_no < ?/*EmpNo*/ AND id = ?/*maxEmpNo*/`,
 			wantQuery: `
 			SELECT
 				*
@@ -671,7 +667,6 @@ func TestEval(t *testing.T) {
 				EmpNo:    1000,
 				MaxEmpNo: 10,
 			},
-			// wantQuery:  `SELECT * FROM person WHERE 1=1 AND employee_no < 222 AND id = ?/*maxEmpNo*/`,
 			wantQuery: `
 			SELECT
 				*

--- a/eval_test.go
+++ b/eval_test.go
@@ -695,6 +695,37 @@ func TestEval(t *testing.T) {
 			`,
 			wantParams: []interface{}{10},
 		},
+		{
+			name: "comment",
+			input: `
+			-- header comment
+			SELECT -- inner comment
+				* -- inner comment
+			FROM -- inner comment
+				person -- inner comment
+			WHERE -- inner comment
+				employee_no < 1000 -- inner comment
+				/* IF true */ -- inner comment
+				AND dept_no = 1 -- inner comment
+				/* END */ -- inner comment
+			-- footer comment
+			`,
+			inputParams: Info{},
+			wantQuery: `
+			-- header comment
+			SELECT -- inner comment
+				* -- inner comment
+			FROM -- inner comment
+				person -- inner comment
+			WHERE -- inner comment
+				employee_no < 1000 -- inner comment
+				 -- inner comment
+				AND dept_no = 1 -- inner comment
+				 -- inner comment
+			-- footer comment
+			`,
+			wantParams: []interface{}{},
+		},
 	}
 
 	for _, tt := range tests {

--- a/eval_test.go
+++ b/eval_test.go
@@ -2,6 +2,9 @@ package twowaysql
 
 import (
 	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
 )
 
 type Info struct {
@@ -235,8 +238,18 @@ func TestEval(t *testing.T) {
 				/* END */
 			`,
 			inputParams: Info{},
-			wantQuery:   `SELECT * FROM person WHERE employee_no < 1000 AND dept_no = 1`,
-			wantParams:  []interface{}{},
+			wantQuery: `
+			SELECT
+				*
+			FROM
+				person
+			WHERE
+				employee_no < 1000
+				
+				AND dept_no = 1
+				
+			`,
+			wantParams: []interface{}{},
 		},
 		{
 			name: "multiline if false elif false else",
@@ -270,7 +283,17 @@ func TestEval(t *testing.T) {
 				GenderList: []string{"M", "F"},
 				IntList:    []int{1, 2, 3},
 			},
-			wantQuery:  `SELECT * FROM person WHERE employee_no < 1000 AND id = ?/*maxEmpNo*/`,
+			wantQuery: `
+			SELECT
+				*
+			FROM
+				person
+			WHERE
+				employee_no < 1000
+				
+				AND id = ?/*maxEmpNo*/
+				
+			`,
 			wantParams: []interface{}{3},
 		},
 		{
@@ -311,7 +334,20 @@ func TestEval(t *testing.T) {
 				GenderList: []string{"M", "F"},
 				IntList:    []int{1, 2, 3},
 			},
-			wantQuery:  `SELECT * FROM person WHERE employee_no < 1000 AND id = 3`,
+			// wantQuery:  `SELECT * FROM person WHERE employee_no < 1000 AND id = 3`,
+			wantQuery: `
+			SELECT
+				*
+			FROM
+				person
+			WHERE
+				employee_no	<	1000
+				
+					
+					AND	id			=	3
+					
+				
+			`,
 			wantParams: []interface{}{},
 		},
 		{
@@ -338,7 +374,17 @@ func TestEval(t *testing.T) {
 				GenderList: []string{"M", "F"},
 				IntList:    []int{1, 2, 3},
 			},
-			wantQuery: `SELECT * FROM person WHERE employee_no = ?/*maxEmpNo*/ AND person.gender in (?, ?, ?)/*int_list*/`,
+			wantQuery: `
+			SELECT
+				*
+			FROM
+				person
+			WHERE
+				employee_no		=	?/*maxEmpNo*/
+				
+				AND	person.gender	in	(?, ?, ?)/*int_list*/
+				
+			`,
 			wantParams: []interface{}{
 				3,
 				1,
@@ -385,7 +431,34 @@ func TestEval(t *testing.T) {
 				Email:      "email",
 				GenderList: []string{"f", "m", "o"},
 			},
-			wantQuery:  `SELECT * FROM person WHERE 1=1 AND employee_no < ?/*EmpNo*/ AND id = ?/*maxEmpNo*/ AND dept_no = ?/*deptNo*/ AND first_name = ?/*firstName*/ AND last_name = ?/*lastName*/ AND email = ?/*email*/ AND gender_list IN (?, ?, ?)/*gender_list*/`,
+			wantQuery: `
+			SELECT
+				*
+			FROM
+				person
+			WHERE	1=1
+				
+				 AND employee_no < ?/*EmpNo*/
+				
+				
+				 AND id = ?/*maxEmpNo*/
+				
+				
+				 AND dept_no = ?/*deptNo*/
+				
+				
+				 AND first_name = ?/*firstName*/
+				
+				
+				 AND last_name = ?/*lastName*/
+				
+				
+				 AND email = ?/*email*/
+				
+				
+				 AND gender_list IN (?, ?, ?)/*gender_list*/
+				
+			`,
 			wantParams: []interface{}{1000, 10, 1, "first", "last", "email", "f", "m", "o"},
 		},
 		{
@@ -407,7 +480,18 @@ func TestEval(t *testing.T) {
 				EmpNo:    1000,
 				MaxEmpNo: 10,
 			},
-			wantQuery:  `SELECT * FROM person WHERE 1=1 AND id = ?/*maxEmpNo*/`,
+			// wantQuery:  `SELECT * FROM person WHERE 1=1 AND id = ?/*maxEmpNo*/`,
+			wantQuery: `
+			SELECT
+				*
+			FROM
+				person
+			WHERE	1=1
+				
+				
+				 AND id = ?/*maxEmpNo*/
+				
+			`,
 			wantParams: []interface{}{10},
 		},
 		{
@@ -440,7 +524,22 @@ func TestEval(t *testing.T) {
 				EmpNo:    1000,
 				MaxEmpNo: 10,
 			},
-			wantQuery:  `SELECT * FROM person WHERE 1=1 AND employee_no < ?/*EmpNo*/ AND id = ?/*maxEmpNo*/`,
+			// wantQuery:  `SELECT * FROM person WHERE 1=1 AND employee_no < ?/*EmpNo*/ AND id = ?/*maxEmpNo*/`,
+			wantQuery: `
+			SELECT
+				*
+			FROM
+				person
+			WHERE	1=1
+				
+					
+						AND employee_no < ?/*EmpNo*/
+					
+					
+						AND id = ?/*maxEmpNo*/
+					
+				
+			`,
 			wantParams: []interface{}{1000, 10},
 		},
 		{
@@ -473,7 +572,22 @@ func TestEval(t *testing.T) {
 				EmpNo:    1000,
 				MaxEmpNo: 10,
 			},
-			wantQuery:  `SELECT * FROM person WHERE 1=1 AND employee_no < ?/*EmpNo*/ AND id = ?/*maxEmpNo*/`,
+			// wantQuery:  `SELECT * FROM person WHERE 1=1 AND employee_no < ?/*EmpNo*/ AND id = ?/*maxEmpNo*/`,
+			wantQuery: `
+			SELECT
+				*
+			FROM
+				person
+			WHERE	1=1
+				
+					
+						AND employee_no < ?/*EmpNo*/
+					
+					
+						AND id = ?/*maxEmpNo*/
+					
+				
+			`,
 			wantParams: []interface{}{1000, 10},
 		},
 		{
@@ -506,7 +620,21 @@ func TestEval(t *testing.T) {
 				EmpNo:    1000,
 				MaxEmpNo: 10,
 			},
-			wantQuery:  `SELECT * FROM person WHERE 1=1 AND employee_no < ?/*EmpNo*/ AND id = ?/*maxEmpNo*/`,
+			wantQuery: `
+			SELECT
+				*
+			FROM
+				person
+			WHERE	1=1
+				
+					
+						AND employee_no < ?/*EmpNo*/
+					
+					
+						AND id = ?/*maxEmpNo*/
+					
+				
+			`,
 			wantParams: []interface{}{1000, 10},
 		},
 		{
@@ -543,24 +671,38 @@ func TestEval(t *testing.T) {
 				EmpNo:    1000,
 				MaxEmpNo: 10,
 			},
-			wantQuery:  `SELECT * FROM person WHERE 1=1 AND employee_no < 222 AND id = ?/*maxEmpNo*/`,
+			// wantQuery:  `SELECT * FROM person WHERE 1=1 AND employee_no < 222 AND id = ?/*maxEmpNo*/`,
+			wantQuery: `
+			SELECT
+				*
+			FROM
+				person
+			WHERE	1=1
+				
+					
+						
+							
+								
+									AND employee_no < 222
+								
+								
+									AND id = ?/*maxEmpNo*/
+								
+							
+						
+					
+				
+			`,
 			wantParams: []interface{}{10},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if query, params, err := Eval(tt.input, &tt.inputParams); err != nil || query != tt.wantQuery || !interfaceSliceEqual(params, tt.wantParams) {
-				if err != nil {
-					t.Error(err)
-				}
-				if query != tt.wantQuery {
-					t.Errorf("Doesn't Match\nexpected: \n%s\n but got: \n%s\n", tt.wantQuery, query)
-				}
-				if !interfaceSliceEqual(params, tt.wantParams) {
-					t.Errorf("Doesn't Match\nexpected: \n%v\n but got: \n%v\n", tt.wantParams, params)
-				}
-			}
+			query, params, err := Eval(tt.input, &tt.inputParams)
+			assert.NilError(t, err)
+			assert.Check(t, cmp.DeepEqual(tt.wantParams, params))
+			assert.Check(t, cmp.DeepEqual(tt.wantQuery, query))
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,11 @@ module github.com/future-architect/go-twowaysql
 go 1.16
 
 require (
+	github.com/google/go-cmp v0.5.5
 	github.com/jmoiron/sqlx v1.3.1
 	github.com/lib/pq v1.9.0
 	github.com/robertkrimen/otto v0.0.0-20200922221731-ef014fd054ac
 	gitlab.com/osaki-lab/tagscanner v0.1.2
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
+	gotest.tools/v3 v3.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/jmoiron/sqlx v1.3.1 h1:aLN7YINNZ7cYOPK3QC83dbM6KT0NMqVMw961TqrejlE=
 github.com/jmoiron/sqlx v1.3.1/go.mod h1:2BljVx/86SuTyjE+aPYlHCTNvZrnJXghYGpNiXLBMCQ=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
@@ -13,6 +15,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/robertkrimen/otto v0.0.0-20200922221731-ef014fd054ac h1:kYPjbEN6YPYWWHI6ky1J813KzIq/8+Wg4TO4xU7A/KU=
 github.com/robertkrimen/otto v0.0.0-20200922221731-ef014fd054ac/go.mod h1:xvqspoSXJTIpemEonrMDFq6XzwHYYgToXWj5eRX1OtY=
+github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -39,9 +42,13 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/sourcemap.v1 v1.0.5 h1:inv58fC9f9J3TK2Y2R1NPntXEn3/wjWHkonhIUODNTI=
 gopkg.in/sourcemap.v1 v1.0.5/go.mod h1:2RlvNNSMglmRrcvhfuzp4hQHwOtjxlbjX7UPY/GXb78=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools/v3 v3.2.0 h1:I0DwBVMGAx26dttAj1BtJLAkVGncrkkUXfJLC4Flt/I=
+gotest.tools/v3 v3.2.0/go.mod h1:Mcr9QNxkg0uMvy/YElmo4SpXgJKWgQvYrT7Kw5RzJ1A=

--- a/tokenizer.go
+++ b/tokenizer.go
@@ -113,7 +113,7 @@ func tokenize(str string) ([]token, error) {
 					}
 					index++
 				} else {
-					for index < length && str[index] != ' ' && str[index] != ',' && str[index] != ')' {
+					for index < length && str[index] != '\t' && str[index] != '\n' && str[index] != ' ' && str[index] != ',' && str[index] != ')' {
 						index++
 					}
 				}

--- a/tokenizer.go
+++ b/tokenizer.go
@@ -168,6 +168,8 @@ func bindLiteral(str string) string {
 func retrieveCondition(kind tokenKind, str string) string {
 	str = removeCommentSymbol(str)
 	str = strings.Trim(str, " ")
+	str = strings.Trim(str, "\n")
+	str = strings.Trim(str, "\t")
 	switch kind {
 	case tkIf:
 		str = strings.TrimPrefix(str, "IF")

--- a/tokenizer_test.go
+++ b/tokenizer_test.go
@@ -2,6 +2,10 @@ package twowaysql
 
 import (
 	"testing"
+
+	gocmp "github.com/google/go-cmp/cmp"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
 )
 
 func TestTokenize(t *testing.T) {
@@ -408,6 +412,612 @@ func TestTokenizeShouldReturnError(t *testing.T) {
 					t.Errorf("Doesn't Match expected: %v, but got: %v\n", tt.wantError, err.Error())
 				}
 			}
+		})
+	}
+}
+
+func TestTokenize_Multiline(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []token
+	}{
+		{
+			name: "no comment",
+			input: `SELECT
+	*
+FROM
+	person
+WHERE
+	employee_no	<	1000
+AND	dept_no		=	1`,
+			want: []token{
+				{
+					kind: tkSQLStmt,
+					str: `SELECT
+	*
+FROM
+	person
+WHERE
+	employee_no	<	1000
+AND	dept_no		=	1`,
+				},
+				{
+					kind: tkEndOfProgram,
+				},
+			},
+		},
+		{
+			name: "bind  space 1",
+			input: `SELECT
+	*
+FROM
+	person
+WHERE
+	first_name	=	/* firstName */"Jeff Dean"`,
+			want: []token{
+				{
+					kind: tkSQLStmt,
+					str: `SELECT
+	*
+FROM
+	person
+WHERE
+	first_name	=	`,
+				},
+				{
+					kind:  tkBind,
+					str:   "?/* firstName */",
+					value: "firstName",
+				},
+				{
+					kind: tkEndOfProgram,
+				},
+			},
+		},
+		{
+			name: "bind  space 2",
+			input: `SELECT
+	*
+FROM
+	person
+WHERE
+	first_name	=	/* firstName */'Jeff Dean'`,
+			want: []token{
+				{
+					kind: tkSQLStmt,
+					str: `SELECT
+	*
+FROM
+	person
+WHERE
+	first_name	=	`,
+				},
+				{
+					kind:  tkBind,
+					str:   "?/* firstName */",
+					value: "firstName",
+				},
+				{
+					kind: tkEndOfProgram,
+				},
+			},
+		},
+		{
+			name: "bind  space 3",
+			input: `SELECT
+	*
+FROM
+	person
+WHERE
+	first_name	=	/* firstName */"Jeff Dean"
+AND	deptno		<	10`,
+			want: []token{
+				{
+					kind: tkSQLStmt,
+					str: `SELECT
+	*
+FROM
+	person
+WHERE
+	first_name	=	`,
+				},
+				{
+					kind:  tkBind,
+					str:   "?/* firstName */",
+					value: "firstName",
+				},
+				{
+					kind: tkSQLStmt,
+					str: `
+AND	deptno		<	10`,
+				},
+				{
+					kind: tkEndOfProgram,
+				},
+			},
+		},
+		{
+			name: "insert",
+			input: `INSERT
+INTO
+	persons
+(
+	employee_no
+,	dept_no
+,	first_name
+,	last_name
+,	email
+) VALUES (
+	/*EmpNo*/1
+,	/*deptNo*/1
+)`,
+			want: []token{
+				{
+					kind: tkSQLStmt,
+					str: `INSERT
+INTO
+	persons
+(
+	employee_no
+,	dept_no
+,	first_name
+,	last_name
+,	email
+) VALUES (
+	`,
+				},
+				{
+					kind:  tkBind,
+					str:   "?/*EmpNo*/",
+					value: "EmpNo",
+				},
+				{
+					kind: tkSQLStmt,
+					str:  "\n,\t",
+				},
+				{
+					kind:  tkBind,
+					str:   "?/*deptNo*/",
+					value: "deptNo",
+				},
+				{
+					kind: tkSQLStmt,
+					str:  "\n)",
+				},
+				{
+					kind: tkEndOfProgram,
+				},
+			},
+		},
+		{
+			name: "if",
+			input: `SELECT
+	*
+FROM
+	person
+WHERE
+	employee_no	<	1000
+/* IF true */
+	AND	dept_no		=	1
+/* END */`,
+			want: []token{
+				{
+					kind: tkSQLStmt,
+					str: `SELECT
+	*
+FROM
+	person
+WHERE
+	employee_no	<	1000
+`,
+				},
+				{
+					kind:      tkIf,
+					str:       "/* IF true */",
+					condition: "true",
+				},
+				{
+					kind: tkSQLStmt,
+					str: `
+	AND	dept_no		=	1
+`,
+				},
+				{
+					kind: tkEnd,
+					str:  "/* END */",
+				},
+				{
+					kind: tkEndOfProgram,
+				},
+			},
+		},
+		{
+			name: "if and bind",
+			input: `SELECT
+	*
+FROM
+	person
+WHERE
+	employee_no	<	/*maxEmpNo*/1000
+	/* IF false */
+		AND	dept_no		=	/*deptNo*/1
+	/* END */`,
+			want: []token{
+				{
+					kind: tkSQLStmt,
+					str: `SELECT
+	*
+FROM
+	person
+WHERE
+	employee_no	<	`,
+				},
+				{
+					kind:  tkBind,
+					str:   "?/*maxEmpNo*/",
+					value: "maxEmpNo",
+				},
+				{
+					kind: tkSQLStmt,
+					str:  "\n\t",
+				},
+				{
+					kind:      tkIf,
+					str:       "/* IF false */",
+					condition: "false",
+				},
+				{
+					kind: tkSQLStmt,
+					str: `
+		AND	dept_no		=	`,
+				},
+				{
+					kind:  tkBind,
+					str:   "?/*deptNo*/",
+					value: "deptNo",
+				},
+				{
+					kind: tkSQLStmt,
+					str:  "\n\t",
+				},
+				{
+					kind: tkEnd,
+					str:  "/* END */",
+				},
+				{
+					kind: tkEndOfProgram,
+				},
+			},
+		},
+		{
+			name: "if elif else",
+			input: `SELECT
+	*
+FROM
+	person
+WHERE
+	employee_no	<	1000
+	/* IF true */
+		AND	dept_no		=	1
+	/* ELIF true*/
+		AND	boss_no		=	2
+	/*ELSE */
+		AND	ID			=	3
+	/* END */`,
+			want: []token{
+				{
+					kind: tkSQLStmt,
+					str: `SELECT
+	*
+FROM
+	person
+WHERE
+	employee_no	<	1000
+	`,
+				},
+				{
+					kind:      tkIf,
+					str:       "/* IF true */",
+					condition: "true",
+				},
+				{
+					kind: tkSQLStmt,
+					str: `
+		AND	dept_no		=	1
+	`,
+				},
+				{
+					kind:      tkElif,
+					str:       "/* ELIF true*/",
+					condition: "true",
+				},
+				{
+					kind: tkSQLStmt,
+					str: `
+		AND	boss_no		=	2
+	`,
+				},
+				{
+					kind: tkElse,
+					str:  "/*ELSE */",
+				},
+				{
+					kind: tkSQLStmt,
+					str: `
+		AND	ID			=	3
+	`,
+				},
+				{
+					kind: tkEnd,
+					str:  "/* END */",
+				},
+				{
+					kind: tkEndOfProgram,
+				},
+			},
+		},
+		{
+			name: "if nest",
+			input: `SELECT
+	*
+FROM
+	person
+WHERE
+	employee_no	<	1000
+	/* IF true */
+		/* IF false */
+		AND	dept_no		=	1
+		/* ELSE */
+		AND	ID			=	3
+		/* END */
+	/* ELSE*/
+		AND	boss_id		=	4
+	/* END */`,
+			want: []token{
+				{
+					kind: tkSQLStmt,
+					str: `SELECT
+	*
+FROM
+	person
+WHERE
+	employee_no	<	1000
+	`,
+				},
+				{
+					kind:      tkIf,
+					str:       "/* IF true */",
+					condition: "true",
+				},
+				{
+					kind: tkSQLStmt,
+					str:  "\n\t\t",
+				},
+				{
+					kind:      tkIf,
+					str:       "/* IF false */",
+					condition: "false",
+				},
+				{
+					kind: tkSQLStmt,
+					str: `
+		AND	dept_no		=	1
+		`,
+				},
+				{
+					kind: tkElse,
+					str:  "/* ELSE */",
+				},
+				{
+					kind: tkSQLStmt,
+					str: `
+		AND	ID			=	3
+		`,
+				},
+				{
+					kind: tkEnd,
+					str:  "/* END */",
+				},
+				{
+					kind: tkSQLStmt,
+					str:  "\n\t",
+				},
+				{
+					kind: tkElse,
+					str:  "/* ELSE*/",
+				},
+				{
+					kind: tkSQLStmt,
+					str: `
+		AND	boss_id		=	4
+	`,
+				},
+				{
+					kind: tkEnd,
+					str:  "/* END */",
+				},
+				{
+					kind: tkEndOfProgram,
+				},
+			},
+		},
+		{
+			name: "in bind",
+			input: `SELECT
+	*
+FROM
+	person
+/* IF gender_list !== null */
+WHERE
+	person.gender	IN	/*gender_list*/('M')
+/* END */`,
+			want: []token{
+				{
+					kind: tkSQLStmt,
+					str: `SELECT
+	*
+FROM
+	person
+`,
+				},
+				{
+					kind:      tkIf,
+					str:       "/* IF gender_list !== null */",
+					condition: "gender_list !== null",
+				},
+				{
+					kind: tkSQLStmt,
+					str: `
+WHERE
+	person.gender	IN	`,
+				},
+				{
+					kind:  tkBind,
+					str:   "?/*gender_list*/",
+					value: "gender_list",
+				},
+				{
+					kind: tkSQLStmt,
+					str:  "\n",
+				},
+				{
+					kind: tkEnd,
+					str:  "/* END */",
+				},
+				{
+					kind: tkEndOfProgram,
+				},
+			},
+		},
+		{
+			name: "multiple in bind",
+			input: `SELECT
+	*
+FROM
+	person
+/* IF gender_list !== null */
+WHERE
+	(person.gender, person.firstname)	IN	/*table*/('M', 'Jeff')
+/* END */`,
+			want: []token{
+				{
+					kind: tkSQLStmt,
+					str: `SELECT
+	*
+FROM
+	person
+`,
+				},
+				{
+					kind:      tkIf,
+					str:       "/* IF gender_list !== null */",
+					condition: "gender_list !== null",
+				},
+				{
+					kind: tkSQLStmt,
+					str: `
+WHERE
+	(person.gender, person.firstname)	IN	`,
+				},
+				{
+					kind:  tkBind,
+					str:   "?/*table*/",
+					value: "table",
+				},
+				{
+					kind: tkSQLStmt,
+					str:  "\n",
+				},
+				{
+					kind: tkEnd,
+					str:  "/* END */",
+				},
+				{
+					kind: tkEndOfProgram,
+				},
+			},
+		},
+		{
+			name: "header comment",
+			input: `-- header comment
+SELECT
+	*
+FROM
+	person
+WHERE
+	employee_no	<	1000`,
+			want: []token{
+				{
+					kind: tkSQLStmt,
+					str: `-- header comment
+SELECT
+	*
+FROM
+	person
+WHERE
+	employee_no	<	1000`,
+				},
+				{
+					kind: tkEndOfProgram,
+				},
+			},
+		},
+		{
+			name: "inner comment",
+			input: `SELECT
+	*
+FROM
+	person	-- inner comment
+WHERE
+	employee_no	<	1000`,
+			want: []token{
+				{
+					kind: tkSQLStmt,
+					str: `SELECT
+	*
+FROM
+	person	-- inner comment
+WHERE
+	employee_no	<	1000`,
+				},
+				{
+					kind: tkEndOfProgram,
+				},
+			},
+		},
+		{
+			name: "footer comment",
+			input: `SELECT
+	*
+FROM
+	person
+WHERE
+	employee_no	<	1000
+-- footer comment`,
+			want: []token{
+				{
+					kind: tkSQLStmt,
+					str: `SELECT
+	*
+FROM
+	person
+WHERE
+	employee_no	<	1000
+-- footer comment`,
+				},
+				{
+					kind: tkEndOfProgram,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tokenize(tt.input)
+			assert.NilError(t, err)
+			assert.Check(t, cmp.DeepEqual(tt.want, got, gocmp.AllowUnexported(token{})))
 		})
 	}
 }


### PR DESCRIPTION
#11  の対応を実施しました。

#2 で対応した複数行の SQL 実行のための、formatQuery (SQL を一行へコンバート) する処理を削除し、
空白として `タブ` 、 `改行` をサポートするように更新しました。

