### PR TITLE
add sql.NullXXX type parameter support

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -2,6 +2,7 @@ package twowaysql
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"os"
@@ -12,9 +13,11 @@ import (
 )
 
 type Person struct {
-	FirstName string `db:"first_name"`
-	LastName  string `db:"last_name"`
-	Email     string `db:"email"`
+	FirstName  string         `db:"first_name"`
+	LastName   string         `db:"last_name"`
+	Email      string         `db:"email"`
+	NullString sql.NullString `db:"null_string"`
+	NullInt    sql.NullInt64  `db:"null_int"`
 }
 
 func TestSelect(t *testing.T) {
@@ -116,28 +119,32 @@ func TestInsertAndDelete(t *testing.T) {
 	ctx := context.Background()
 
 	var params = Info{
-		EmpNo:     100,
-		FirstName: "Jeff",
-		LastName:  "Dean",
-		DeptNo:    1011,
-		Email:     "jeffdean@example.com",
+		EmpNo:      100,
+		FirstName:  "Jeff",
+		LastName:   "Dean",
+		DeptNo:     1011,
+		Email:      "jeffdean@example.com",
+		NullString: sql.NullString{String: "value", Valid: true},
+		NullInt:    sql.NullInt64{Int64: 11, Valid: false}, // NULL 登録
 	}
-	_, err := tw.Exec(ctx, `INSERT INTO persons (employee_no, dept_no, first_name, last_name, email) VALUES(/*EmpNo*/1, /*deptNo*/1, /*firstName*/"Tim", /*lastName*/"Cook", /*email*/"timcook@example.com")`, &params)
+	_, err := tw.Exec(ctx, `INSERT INTO persons (employee_no, dept_no, first_name, last_name, email, null_string, null_int) VALUES(/*EmpNo*/1, /*deptNo*/1, /*firstName*/"Tim", /*lastName*/"Cook", /*email*/"timcook@example.com", /*null_string*/'null', /*null_int*/1)`, &params)
 	if err != nil {
 		t.Fatalf("exec: failed: %v", err)
 	}
 
 	var people []Person
-	err = tw.Select(ctx, &people, `SELECT first_name, last_name, email FROM persons WHERE dept_no = /*deptNo*/0`, &params)
+	err = tw.Select(ctx, &people, `SELECT first_name, last_name, email, null_string, null_int FROM persons WHERE dept_no = /*deptNo*/0`, &params)
 	if err != nil {
 		t.Fatalf("select: failed: %v", err)
 	}
 
 	var expected = []Person{
 		{
-			FirstName: "Jeff",
-			LastName:  "Dean",
-			Email:     "jeffdean@example.com",
+			FirstName:  "Jeff",
+			LastName:   "Dean",
+			Email:      "jeffdean@example.com",
+			NullString: sql.NullString{String: "value", Valid: true},
+			NullInt:    sql.NullInt64{Int64: 0, Valid: false}, // NULL 確認
 		},
 	}
 	if !match(people, expected) {

--- a/postgres/init/init.sql
+++ b/postgres/init/init.sql
@@ -3,7 +3,9 @@ CREATE TABLE persons (
 		dept_no INT,
 		first_name VARCHAR(100),
 		last_name VARCHAR(100),
-		email VARCHAR(100)
+		email VARCHAR(100),
+		null_string VARCHAR(100),
+		null_int INT
 		);
 
 INSERT INTO persons(employee_no, dept_no, first_name, last_name, email) VALUES


### PR DESCRIPTION
## 概要
sql.NullXXX 型をパラメータ指定できるようにアップデートしました。

## 問題
tagscanner で sql.NullXXX 型がエンコードされず、パラメータから抜け落ちる問題が発生しています。

## 対応

* sql.NullXXX 型は go-twowaysql 側の実装で吸収し、パラメータの map へ詰めるようにしました
   * tagscanner が nest した struct に[未対応](https://gitlab.com/osaki-lab/tagscanner/-/blob/main/runtimescan/encode.go#L44)である点と、対応していたとしても sql.NullXXX 型に `db` や `twowaysql` タグが付与されないためエンコードできないためです

## テスト

```sh
~/.ghq/github.com/future-architect/go-twowaysql feature/fix-sqlnulltype *2                                                                                                                                                                           14:52:35
❯ go test -count=1 ./...                  
ok      github.com/future-architect/go-twowaysql        0.399s
```

## 補足

* struct パラメータのみ対応しており、map パラメータの場合は未対応です