### PR TITLE
add time.Time parameter support

### DIFF
--- a/eval_test.go
+++ b/eval_test.go
@@ -26,6 +26,8 @@ type Info struct {
 	Table      [][]interface{} `twowaysql:"table"`
 	NullString sql.NullString  `twowaysql:"null_string"`
 	NullInt    sql.NullInt64   `twowaysql:"null_int"`
+	CreatedAt  time.Time       `twowaysql:"created_at"`
+	UpdatedAt  sql.NullTime    `twowaysql:"updated_at"`
 }
 
 func TestEval(t *testing.T) {
@@ -1119,7 +1121,7 @@ func TestEvalWithMap(t *testing.T) {
 	}
 }
 
-func TestEval_SQLNullTyp(t *testing.T) {
+func TestEval_NestStructTyp(t *testing.T) {
 	type SQLTypInfo struct {
 		NullBool    sql.NullBool    `db:"null_bool"`
 		NullFloat64 sql.NullFloat64 `db:"null_float_64"`
@@ -1128,6 +1130,7 @@ func TestEval_SQLNullTyp(t *testing.T) {
 		NullInt64   sql.NullInt64   `db:"null_int_64"`
 		NullString  sql.NullString  `db:"null_string"`
 		NullTime    sql.NullTime    `db:"null_time"`
+		Time        time.Time       `db:"time"`
 	}
 
 	tests := []struct {
@@ -1201,6 +1204,15 @@ func TestEval_SQLNullTyp(t *testing.T) {
 				},
 			},
 			wantQuery:  `SELECT * FROM person WHERE value = ?/*null_time*/`,
+			wantParams: []interface{}{time.Date(2022, 7, 1, 12, 30, 30, 0, time.UTC)},
+		},
+		{
+			name:  "bind time.Time",
+			input: `SELECT * FROM person WHERE value = /*time*/'2022-01-01 10:00:00'`,
+			inputParams: SQLTypInfo{
+				Time: time.Date(2022, 7, 1, 12, 30, 30, 0, time.UTC),
+			},
+			wantQuery:  `SELECT * FROM person WHERE value = ?/*time*/`,
 			wantParams: []interface{}{time.Date(2022, 7, 1, 12, 30, 30, 0, time.UTC)},
 		},
 		{

--- a/postgres/init/init.sql
+++ b/postgres/init/init.sql
@@ -5,11 +5,13 @@ CREATE TABLE persons (
 		last_name VARCHAR(100),
 		email VARCHAR(100),
 		null_string VARCHAR(100),
-		null_int INT
+		null_int INT,
+		created_at timestamp with time zone NOT NULL,
+		updated_at timestamp with time zone
 		);
 
-INSERT INTO persons(employee_no, dept_no, first_name, last_name, email) VALUES
-			(1, 10, 'Evan', 'MacMans', 'evanmacmans@example.com'),
-			(2, 11, 'Malvina', 'FitzSimons', 'malvinafitzsimons@example.com'),
-			(3, 12, 'Jimmie', 'Bruce', 'jimmiebruce@example.com')
+INSERT INTO persons(employee_no, dept_no, first_name, last_name, email, created_at) VALUES
+			(1, 10, 'Evan', 'MacMans', 'evanmacmans@example.com', CURRENT_TIMESTAMP),
+			(2, 11, 'Malvina', 'FitzSimons', 'malvinafitzsimons@example.com', CURRENT_TIMESTAMP),
+			(3, 12, 'Jimmie', 'Bruce', 'jimmiebruce@example.com', CURRENT_TIMESTAMP)
 			;


### PR DESCRIPTION
struct パラメータ時の、time.Time 型のパラメータ指定をサポートしました。

```sh
~/.ghq/github.com/future-architect/go-twowaysql feature/add-support-time *2 +2 !1                                                                                                                                                                        16:44:30
❯ go test -count=1 ./...
ok      github.com/future-architect/go-twowaysql        0.370s
```