### PR TITLE
add returning sqlx interface support

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -342,7 +342,7 @@ func TestTxBlock(t *testing.T) {
 		FirstName string `twowaysql:"firstName"`
 	}
 	// commit case
-	err := tw.Transaction(ctx, func(tx TwowaysqlTx) error {
+	err := tw.Transaction(ctx, func(tx *TwowaysqlTx) error {
 		// update
 		const sql = `
 		UPDATE
@@ -369,7 +369,7 @@ func TestTxBlock(t *testing.T) {
 	}
 
 	// rollcack case
-	err = tw.Transaction(ctx, func(tx TwowaysqlTx) error {
+	err = tw.Transaction(ctx, func(tx *TwowaysqlTx) error {
 		// update
 		const sql = `
 		UPDATE

--- a/twowaysql.go
+++ b/twowaysql.go
@@ -72,6 +72,11 @@ func (t *Twowaysql) Close() error {
 	return nil
 }
 
+// DB returns `*sqlx.DB`
+func (t *Twowaysql) DB() *sqlx.DB {
+	return t.db
+}
+
 // Transaction starts a transaction as a block.
 // arguments function is return error will rollback, otherwise to commit.
 func (t *Twowaysql) Transaction(ctx context.Context, fn func(tx TwowaysqlTx) error) error {
@@ -149,4 +154,9 @@ func (t *TwowaysqlTx) Exec(ctx context.Context, query string, params interface{}
 	q := t.tx.Rebind(eval)
 
 	return t.tx.ExecContext(ctx, q, bindParams...)
+}
+
+// Tx returns `*sqlx.Tx`
+func (t *TwowaysqlTx) Tx() *sqlx.Tx {
+	return t.tx
 }

--- a/twowaysql.go
+++ b/twowaysql.go
@@ -79,13 +79,13 @@ func (t *Twowaysql) DB() *sqlx.DB {
 
 // Transaction starts a transaction as a block.
 // arguments function is return error will rollback, otherwise to commit.
-func (t *Twowaysql) Transaction(ctx context.Context, fn func(tx TwowaysqlTx) error) error {
+func (t *Twowaysql) Transaction(ctx context.Context, fn func(tx *TwowaysqlTx) error) error {
 	tx, err := t.Begin(ctx)
 	if err != nil {
 		return err
 	}
 
-	if err := fn(*tx); err != nil {
+	if err := fn(tx); err != nil {
 		if rerr := tx.Rollback(); rerr != nil {
 			return fmt.Errorf("failed rollback %v: %w", rerr, err)
 		}


### PR DESCRIPTION
* sqlx のインターフェイスを返却するメソッドを追加
  * bulk insert 等の go-twowaysql で未サポートの機能の利用のため
* Transaction 内に渡される引数をポインタ型へ変更
  * 不要なコピーを避けるため