### PR TITLE
add rollback process in case of panic

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -446,34 +446,6 @@ func TestTxBlock(t *testing.T) {
 		t.Error("unexpecte err == nil")
 	}
 
-	// rollcack case (panic recover)
-	err = tw.Transaction(ctx, func(tx *TwowaysqlTx) error {
-		// update
-		const sql = `
-		UPDATE
-			persons
-		SET first_name = /*firstName*/Jon
-		WHERE employee_no = /*EmpNo*/10`
-		param := Param{EmpNo: 14, FirstName: "ROLLBACKED(PANIC)"}
-		res, err := tx.Exec(ctx, sql, &param)
-		if err != nil {
-			return err
-		}
-		rows, err := res.RowsAffected()
-		if err != nil {
-			return err
-		}
-		if rows != 1 {
-			return fmt.Errorf("update rows = %v", rows)
-		}
-
-		// occure panic
-		panic("test panic")
-	})
-	if err == nil {
-		t.Error("unexpecte err == nil")
-	}
-
 	// check
 	people := []Person{}
 	const checkSQL = `SELECT first_name, last_name, email FROM persons WHERE employee_no IN (13, 14) order by employee_no`
@@ -498,6 +470,80 @@ func TestTxBlock(t *testing.T) {
 		t.Errorf("expected:\n%v\nbut got\n%v\n", expectedAfterCommit, people)
 	}
 
+}
+
+func TestTxBlockPanic(t *testing.T) {
+	//このテストはinit.sqlに依存しています。
+	//データベースは/postgres/init以下のsqlファイルを用いて初期化されている。
+	db := open(t)
+	defer db.Close()
+	tw := New(db)
+	ctx := context.Background()
+
+	// insert test data
+	const insertSQL = `
+	INSERT INTO persons
+		(employee_no, dept_no, first_name, last_name, email, created_at) VALUES
+		(15, 151, 'Tom', 'Mike', 'tommike@example.com', CURRENT_TIMESTAMP)
+		;`
+	if _, err := tw.Exec(ctx, insertSQL, nil); err != nil {
+		t.Fatal(err)
+	}
+	defer tw.Exec(ctx, `DELETE FROM persons WHERE employee_no = 15`, nil)
+
+	type Param struct {
+		EmpNo     int    `twowaysql:"EmpNo"`
+		FirstName string `twowaysql:"firstName"`
+	}
+
+	defer func() {
+		p := recover()
+		assert.Equal(t, p != nil, true)
+
+		// check
+		people := []Person{}
+		const checkSQL = `SELECT first_name, last_name, email FROM persons WHERE employee_no = 15`
+		if err := tw.Select(ctx, &people, checkSQL, nil); err != nil {
+			t.Error(err)
+		}
+		expectedAfterCommit := []Person{
+			{
+				FirstName: "Tom",
+				LastName:  "Mike",
+				Email:     "tommike@example.com",
+			},
+		}
+		if !match(expectedAfterCommit, people) {
+			t.Errorf("expected:\n%v\nbut got\n%v\n", expectedAfterCommit, people)
+		}
+	}()
+
+	// rollcack case (panic recover)
+	err := tw.Transaction(ctx, func(tx *TwowaysqlTx) error {
+		// update
+		const sql = `
+		UPDATE
+			persons
+		SET first_name = /*firstName*/Jon
+		WHERE employee_no = /*EmpNo*/10`
+		param := Param{EmpNo: 15, FirstName: "ROLLBACKED(PANIC)"}
+		res, err := tx.Exec(ctx, sql, &param)
+		if err != nil {
+			return err
+		}
+		rows, err := res.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if rows != 1 {
+			return fmt.Errorf("update rows = %v", rows)
+		}
+
+		// occure panic
+		panic("test panic")
+	})
+
+	assert.NilError(t, err)
 }
 
 func open(t *testing.T) *sqlx.DB {

--- a/twowaysql.go
+++ b/twowaysql.go
@@ -86,7 +86,7 @@ func (t *Twowaysql) DB() *sqlx.DB {
 
 // Transaction starts a transaction as a block.
 // arguments function is return error will rollback, otherwise to commit.
-func (t *Twowaysql) Transaction(ctx context.Context, fn func(tx *TwowaysqlTx) error) (err error) {
+func (t *Twowaysql) Transaction(ctx context.Context, fn func(tx *TwowaysqlTx) error) error {
 	tx, err := t.Begin(ctx)
 	if err != nil {
 		return err
@@ -94,10 +94,9 @@ func (t *Twowaysql) Transaction(ctx context.Context, fn func(tx *TwowaysqlTx) er
 	defer func() {
 		if p := recover(); p != nil {
 			if rerr := tx.Rollback(); rerr != nil {
-				err = fmt.Errorf("panic occured and failed rollback %v: %v", rerr, p)
-				return
+				panic(fmt.Sprintf("panic occured %v and failed rollback %v", p, rerr))
 			}
-			err = fmt.Errorf("panic occured: %v", p)
+			panic(p)
 		}
 	}()
 


### PR DESCRIPTION
パニック発生時に明示的にロールバックする処理を追加しました。  
ライブラリ内のため、パニックは握りつぶさない仕様としています。

[参考(gorm)](https://github.com/go-gorm/gorm/blob/be440e75122de5f7c19e2242a59246a92ce8edfe/finisher_api.go#L583)