### PR TITLE
upgrade github.com/future-architect/tagscanner v1.0.1 => v1.0.3

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -11,6 +11,7 @@ import (
 
 	_ "github.com/jackc/pgx/v4/stdlib"
 	"github.com/jmoiron/sqlx"
+	"golang.org/x/sync/errgroup"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
 )
@@ -159,6 +160,76 @@ func TestUpdate(t *testing.T) {
 		},
 	}
 	assert.Check(t, cmp.DeepEqual(people, expected))
+}
+
+func TestExec_Parallel(t *testing.T) {
+	//このテストはinit.sqlに依存しています。
+	//データベースは/postgres/init以下のsqlファイルを用いて初期化されている。
+
+	db := open(t)
+	defer db.Close()
+	tw := New(db)
+	ctx := context.Background()
+
+	var params = []Info{}
+	var expect []Person
+
+	for i := 0; i < 100; i++ {
+		empNo := i + 4
+		info :=
+			Info{
+				EmpNo:     empNo,
+				DeptNo:    1,
+				FirstName: fmt.Sprintf("FirstName-%d", empNo),
+				LastName:  fmt.Sprintf("LastName-%d", empNo),
+				Email:     fmt.Sprintf("%d@test", empNo),
+			}
+		params = append(params, info)
+
+		person :=
+			Person{
+				FirstName: fmt.Sprintf("FirstName-%d", empNo),
+				LastName:  fmt.Sprintf("LastName-%d", empNo),
+				Email:     fmt.Sprintf("%d@test", empNo),
+			}
+		expect = append(expect, person)
+	}
+
+	sql :=
+		`
+		INSERT INTO persons(employee_no, dept_no, first_name, last_name, email, created_at) VALUES
+		(/*EmpNo*/1, /*deptNo*/1, /*firstName*/'firstName', /*lastName*/'lastName', /*email*/'temp', CURRENT_TIMESTAMP)
+	`
+
+	eg := new(errgroup.Group)
+
+	for _, param := range params {
+		p := param
+		eg.Go(func() error {
+			_, err := tw.Exec(ctx, sql, &p)
+			return err
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		t.Fatalf("exec: failed: %v", err)
+	}
+
+	var people []Person
+	err := tw.Select(ctx, &people, `SELECT first_name, last_name, email FROM persons WHERE dept_no = 1 order by employee_no`, nil)
+	if err != nil {
+		t.Fatalf("select: failed: %v", err)
+	}
+
+	// 元に戻す。
+	for _, param := range params {
+		p := param
+		_, err = tw.Exec(ctx, `DELETE from persons WHERE employee_no = /*EmpNo*/1`, &p)
+		if err != nil {
+			t.Fatalf("exec: failed: %v", err)
+		}
+	}
+
+	assert.Check(t, cmp.DeepEqual(people, expect))
 }
 
 func TestInsertAndDelete(t *testing.T) {

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -201,7 +201,7 @@ func TestExec_Parallel(t *testing.T) {
 		(/*EmpNo*/1, /*deptNo*/1, /*firstName*/'firstName', /*lastName*/'lastName', /*email*/'temp', CURRENT_TIMESTAMP)
 	`
 
-	eg := new(errgroup.Group)
+	var eg errgroup.Group
 
 	for _, param := range params {
 		p := param

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/alecthomas/chroma v0.10.0
 	github.com/fatih/color v1.13.0
-	github.com/future-architect/tagscanner v1.0.1
+	github.com/future-architect/tagscanner v1.0.3
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/goccy/go-yaml v1.9.5
 	github.com/google/go-cmp v0.5.9
@@ -28,10 +28,12 @@ require (
 	github.com/shibukawa/mdd-go v0.1.7
 	github.com/stretchr/testify v1.8.0
 	golang.org/x/crypto v0.0.0-20221005025214-4161e89ecf1b
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
+	github.com/Songmu/gocredits v0.2.0 // indirect
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/alecthomas/chroma/v2 v2.2.0 // indirect
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
+github.com/Songmu/gocredits v0.2.0 h1:AbvFKEbwP5/0qisF0cTlUwVuCtzbJG+ynsXuEUC98vI=
+github.com/Songmu/gocredits v0.2.0/go.mod h1:JBywHzwOmBMF9uidu1EgS3mwVNqZCKOPLPrFd1h7qQo=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/alecthomas/chroma v0.10.0 h1:7XDcGkCQopCNKjZHfYrNLraA+M7e0fMiJ/Mfikbfjek=
@@ -31,6 +33,8 @@ github.com/future-architect/go-exceltesting v0.3.1 h1:7/1VT2MBp22bacsyIJn5WI8k3+
 github.com/future-architect/go-exceltesting v0.3.1/go.mod h1:IaQnLhItvrqgGVSjOjXjqkeLPuaXNja6QnLJWt9t/A8=
 github.com/future-architect/tagscanner v1.0.1 h1:a3bEyiWbPeI5Py1aZkrGpo9CRO7zMrvxNgKrzRbph4k=
 github.com/future-architect/tagscanner v1.0.1/go.mod h1:8oNrgjBYshWEPUCUNbOzxuaoPcB6ifKzUi4jIC0BcgA=
+github.com/future-architect/tagscanner v1.0.3 h1:pAyQnvGEhnv2DQdIps055XkUDgiifeZRiZy8BxX61kA=
+github.com/future-architect/tagscanner v1.0.3/go.mod h1:8oNrgjBYshWEPUCUNbOzxuaoPcB6ifKzUi4jIC0BcgA=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
@@ -242,6 +246,8 @@ golang.org/x/net v0.0.0-20220407224826-aac1ed45d8e3 h1:EN5+DfgmRMvRUrMGERW2gQl3V
 golang.org/x/net v0.0.0-20220407224826-aac1ed45d8e3/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
#Issue
https://github.com/future-architect/go-twowaysql/issues/35

# Related Topic
https://github.com/future-architect/tagscanner/pull/2

# Changed Points
upgrade github.com/future-architect/tagscanner v1.0.1 => v1.0.3

Add a test that calls Exec() in parallel.

# What's I hope
1. After this pull request merge, I hope a new version be released.
2. Because go-twowayssql is using tagscanner, we can't use go-twowqysql in the goroutine. I want a new version using the new tagscanner.