### PR TITLE
skip hints in tokenizer

### DIFF
--- a/tokenizer.go
+++ b/tokenizer.go
@@ -37,6 +37,11 @@ func tokenize(str string) ([]token, error) {
 
 	for index < length {
 		if str[index:index+2] == "/*" {
+			if str[index:index+3] == "/*+" {
+				// hint句の場合はskipする
+				index++
+				continue
+			}
 			//コメントの直前の塊をTKSQLStmtとしてappend
 			tokens = append(tokens, token{
 				kind: tkSQLStmt,


### PR DESCRIPTION
- ヒント句には、twowaysqlコメント用の構文解析処理をスキップするようにしました。
